### PR TITLE
Add training script for CPC data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# CPC Dataset Modeling
+
+This repository contains datasets for the Choice Prediction Competition (CPC) project and a simple training script.
+
+## Files
+
+- `Competition background2025.06.10 (1).pdf` – background description of the competition.
+- `Readme CPC training variables names 2025.04.22 (2).docx` – description of variables in the dataset.
+- `Training 2025.04.22DM (2).xlsx` – spreadsheet of training data.
+- `gpt_cpc_1000 oneshot DM (1).csv` – CSV version with textual descriptions used by the training script.
+- `train_model.py` – Python script that trains a regression model predicting the A-rate from task parameters.
+
+## Requirements
+
+- Python 3.11+
+- `pandas`
+- `scikit-learn`
+
+Install the Python dependencies with:
+
+```bash
+pip install pandas scikit-learn
+```
+
+## Usage
+
+Run the training script:
+
+```bash
+python train_model.py
+```
+
+The script reads the CSV file, splits it into training and test sets, builds a pipeline with TF‑IDF encoding for text fields and a random forest regressor, then prints the mean absolute error on the test set.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+scikit-learn

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_absolute_error
+import re
+
+def load_data(path):
+    df = pd.read_csv(path)
+    # extract numeric problem number
+    df['problem_num'] = df['problem_num'].str.extract(r'(\d+)').astype(int)
+    return df
+
+def build_model():
+    numeric_features = ['task', 'problem_num', 'a1', 'pa1', 'a2',
+                        'b1', 'pb1', 'b2', 'corrAB', 'N']
+    text_features = ['A_Lab', 'B_Lab']
+
+    preprocessor = ColumnTransformer([
+        ('num', 'passthrough', numeric_features),
+        ('txt', TfidfVectorizer(), 'A_Lab'),
+        ('txt2', TfidfVectorizer(), 'B_Lab')
+    ])
+    model = RandomForestRegressor(n_estimators=200, random_state=42)
+    return Pipeline([
+        ('preprocessor', preprocessor),
+        ('model', model)
+    ])
+
+def train(path):
+    df = load_data(path)
+    X = df.drop('A_rates', axis=1)
+    y = df['A_rates']
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    pipeline = build_model()
+    pipeline.fit(X_train, y_train)
+    preds = pipeline.predict(X_test)
+    mae = mean_absolute_error(y_test, preds)
+    print(f"MAE: {mae:.4f}")
+    return pipeline
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Train model on CPC dataset')
+    parser.add_argument('--csv', default='gpt_cpc_1000 oneshot DM (1).csv', help='Path to dataset CSV')
+    args = parser.parse_args()
+    train(args.csv)


### PR DESCRIPTION
## Summary
- add a Python training script using scikit-learn
- include README with instructions
- specify dependencies in requirements.txt

## Testing
- `python train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6868f9ab13bc8321a3d7741962e0e56a